### PR TITLE
Makefile feature creep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ CFLAGS+= -Wall -Wextra
 CFLAGS+= -Wno-attributes -Wno-pointer-sign -Wno-sign-compare
 CFLAGS+= -Wno-unused-parameter
 
-.PHONY: fetch hash-helpers clean install test check-updates
+.PHONY: fetch hash-helpers clean install test check check-updates
 
 signify: ${LOCAL_SRCS} ${SRCS} ${INCL}
 	cc ${CFLAGS} -o signify ${SRCS} ${LOCAL_SRCS}
@@ -104,6 +104,8 @@ install: signify
 	install -d ${BINDIR} ${MANDIR}/man1
 	install -Ss -m 755 signify ${BINDIR}
 	install -S -m 644 signify.1 ${MANDIR}/man1
+
+check: test
 
 test: signify
 	@sh ./regress.sh


### PR DESCRIPTION
Please consider these. Being able to set an alternate install location is essential for packaging.
