### PR TITLE
Adding newer OpenBSD signing keys

### DIFF
--- a/keys/openbsd-59-base.pub
+++ b/keys/openbsd-59-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 5.9 base public key
+RWQJVNompF3pwfIqbg+5sxfpxmZMa3tTBaW4qbUhWje/H/M7glrA6oVn

--- a/keys/openbsd-59-fw.pub
+++ b/keys/openbsd-59-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 5.9 firmware public key
+RWSdmaNkytzh6BApmPSNSDLNg26ZaXlY8g/879UvLdo3rjbsby76Eda1

--- a/keys/openbsd-59-pkg.pub
+++ b/keys/openbsd-59-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 5.9 packages public key
+RWSLRYDCTJeWLIScncqwGuXK6JVXDcIyRT0q+0m30MXXG4W2xWS4NZBP

--- a/keys/openbsd-60-base.pub
+++ b/keys/openbsd-60-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 6.0 base public key
+RWSho3oKSqgLQy+NpIhFXZJDtkE65tzlmtC24mStf8DoJd2OPMgna4u8

--- a/keys/openbsd-60-fw.pub
+++ b/keys/openbsd-60-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.0 firmware public key
+RWRWf7GJKFvJTWEMIaw9wld0DujiqL1mlrC6HisE6i78C+2SRArV1Iyo

--- a/keys/openbsd-60-pkg.pub
+++ b/keys/openbsd-60-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.0 packages public key
+RWQHIajRlT2mX7tmRgb6oN6mfJu3AgQ/TU38acrWABO8lz90dR3rNmey

--- a/keys/openbsd-61-base.pub
+++ b/keys/openbsd-61-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 6.1 base public key
+RWQEQa33SgQSEsMwwVV1+GjzdcQfRNV2Bgo48Ztd2KiZ9bAodz9c+Maa

--- a/keys/openbsd-61-fw.pub
+++ b/keys/openbsd-61-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.1 firmware public key
+RWS91POk0QZXfsqi4aI7MotYz8CPzoHjYg4a1IDi56cftacjsq+ZL/KY

--- a/keys/openbsd-61-pkg.pub
+++ b/keys/openbsd-61-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.1 packages public key
+RWQbTjGFHEvnOckqY7u9iABhXAkEpF/6TQ3Mr6bMrWbT1wOM/HnbV9ov

--- a/keys/openbsd-61-syspatch.pub
+++ b/keys/openbsd-61-syspatch.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.1 syspatch public key
+RWRsegDPFjQlnQlptsqnIv0Q+5dSCCkeiAvZUXtrEwXQZkEhTvlPn++D

--- a/keys/openbsd-62-base.pub
+++ b/keys/openbsd-62-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 6.2 base public key
+RWRVWzAMgtyg7g27STK1h1xA6RIwtjex6Vr5Y9q5SC5q5+b0GN4lLhfu

--- a/keys/openbsd-62-fw.pub
+++ b/keys/openbsd-62-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.2 firmware public key
+RWSbA8C2TPUQLi48EqHtg7Rx7KGDt6E/2d8OeJinGZPbpoqGRxA0N2oW

--- a/keys/openbsd-62-pkg.pub
+++ b/keys/openbsd-62-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.2 packages public key
+RWRvEq+UPCq0VGI9ar7VMy+HYKDrOb4WS5JLhdUBiX3qvJgPQjyZSTxI

--- a/keys/openbsd-62-syspatch.pub
+++ b/keys/openbsd-62-syspatch.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.2 syspatch public key
+RWRsbjD1ABhtm6joukOFHqdPYZFoICJUpM257ko69FpP/roGOts+TfXg

--- a/keys/openbsd-63-base.pub
+++ b/keys/openbsd-63-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 6.3 base public key
+RWRxzbLwAd76ZZxHU7wuIFUOVGwl6SjNNzanKWTql8w+hui7WLE/72mW

--- a/keys/openbsd-63-fw.pub
+++ b/keys/openbsd-63-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.3 firmware public key
+RWT3tdmiAc+DH/CJOxPFT10kUM90/UcLTgSEUEKzhKm9QEhy+UD4CWPy

--- a/keys/openbsd-63-pkg.pub
+++ b/keys/openbsd-63-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.3 packages public key
+RWT58k1AWz/zZO9DHcPHXiHhDNP6hdwGjxNkyMoc/sh4O5NI8Zz1R1lD

--- a/keys/openbsd-63-syspatch.pub
+++ b/keys/openbsd-63-syspatch.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.3 syspatch public key
+RWQvqeEfNMQnoKyOt9UpVE6U7+zKfUSnbNrOHn3Zxijq7z+TyCl759+T

--- a/keys/openbsd-64-base.pub
+++ b/keys/openbsd-64-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 6.4 base public key
+RWQq6XmS4eDAcQW4KsT5Ka0KwTQp2JMOP9V/DR4HTVOL5Bc0D7LeuPwA

--- a/keys/openbsd-64-fw.pub
+++ b/keys/openbsd-64-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.4 firmware public key
+RWRoBbjnosJ/39llpve1XaNIrrQND4knG+jSBeIUYU8x4WNkxz6a2K97

--- a/keys/openbsd-64-pkg.pub
+++ b/keys/openbsd-64-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.4 packages public key
+RWRF5TTY+LoN/51QD5kM2hKDtMTzycQBBPmPYhyQEb1+4pff/H6fh/kA

--- a/keys/openbsd-64-syspatch.pub
+++ b/keys/openbsd-64-syspatch.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.4 syspatch public key
+RWRdGS4hkk0yvnoe8SWXt1Mm8i85MTCSNjQ7wqlNWwufHL4J7azwUqCz

--- a/keys/openbsd-65-base.pub
+++ b/keys/openbsd-65-base.pub
@@ -1,0 +1,2 @@
+untrusted comment: openbsd 6.5 base public key
+RWSZaRmt1LEQT9CtPygf9CvONu8kYPTlVEJdysNoUR62/NkeWgdkc3zY

--- a/keys/openbsd-65-fw.pub
+++ b/keys/openbsd-65-fw.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.5 firmware public key
+RWQYdGVtTv5IvpH2c+TLQAC4iV7RjoGZ/v75q8MCuC9Mca7nFVCXRefy

--- a/keys/openbsd-65-pkg.pub
+++ b/keys/openbsd-65-pkg.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.5 packages public key
+RWS5D4+188RI6jULDOFzga0Cm1zrXYUAHT6xu0mLrZidbn6xrMB5aZeR

--- a/keys/openbsd-65-syspatch.pub
+++ b/keys/openbsd-65-syspatch.pub
@@ -1,0 +1,2 @@
+untrusted comment: OpenBSD 6.5 syspatch public key
+RWT8U2yd3Aq5DnetILjmSoCQxmyt3VqfGS7GBh19oh4Xre4ywc31PEpw


### PR DESCRIPTION
These keys came from the debian [signify-openbsd-keys](https://packages.debian.org/buster/amd64/signify-openbsd-keys/download) package with sha-256 checksum `c718b3606528b7eb4943f9f64d9c4578daf68cd8006de3cf3b3b0a12505d0a2d`.

I also compared the 6.4 "base" key which I have verified in person with 2 OpenBSD developers.  Here is an [OpenPGP signed message certifying that key](https://github.com/jonathancross/jc-docs/blob/master/OpenBSD_release_key_PGP_signature.md).

### Checking keys against openbsd.org

I compared this list: `grep '^RW' openbsd-*.pub` (see [openbsd-keys.txt](https://github.com/jpouellet/signify-osx/files/2636386/openbsd-keys.txt)) to the keys listed on openbsd.org using this 1-liner:

    for I in 64;do for T in base fw pkg; do printf "openbsd-${I}-${T}.pub:"; curl -s https://www.openbsd.org/${I}.html | grep "${T}:.*" | sed 's/.* //';done;done;

Note: This list does not include the `openbsd-*-syspatch.pub` or `openbsd-65-*.pub` keys.  Not sure how to verify those.

Would be great if these were also verified on OpenBSD 6.4 against keys installed with the system.